### PR TITLE
b58decode - Determine whether the return value is out of bounds.

### DIFF
--- a/base58check.go
+++ b/base58check.go
@@ -69,7 +69,13 @@ func Decode(encoded string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, checksum := dataBytes[:len(dataBytes)-4], dataBytes[len(dataBytes)-4:]
+
+	dataBytesLen := len(dataBytes)
+	if dataBytesLen <= 4 {
+		return "", err
+	}
+
+	data, checksum := dataBytes[:dataBytesLen-4], dataBytes[dataBytesLen-4:]
 
 	for i := 0; i < zeroCount; i++ {
 		data = append([]byte{0}, data...)

--- a/base58check.go
+++ b/base58check.go
@@ -72,7 +72,7 @@ func Decode(encoded string) (string, error) {
 
 	dataBytesLen := len(dataBytes)
 	if dataBytesLen <= 4 {
-		return "", err
+		return "", errors.New("b58decode return data len error")
 	}
 
 	data, checksum := dataBytes[:dataBytesLen-4], dataBytes[dataBytesLen-4:]


### PR DESCRIPTION
panic: runtime error: slice bounds out of range

goroutine 205 [running]:
github.com/anaskhan96/base58check.Decode(0x0, 0x0, 0x7a5b80, 0xc4204d94e0, 0x16, 0x16)
build/_workspace/src/github.com/anaskhan96/base58check/base58check.go:72 +0x51e